### PR TITLE
fix: failed actions #59

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
             version: devel
     steps:
       - uses: actions/checkout@v2
-      - run: env | grep SHELL || true
       - uses: ./
         with:
           nim-version: ${{ matrix.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     needs: before
-    env:
-      SHELL: /bin/sh
     strategy:
       matrix:
         os:
@@ -55,6 +53,7 @@ jobs:
             version: devel
     steps:
       - uses: actions/checkout@v2
+      - run: env | grep SHELL || true
       - uses: ./
         with:
           nim-version: ${{ matrix.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     needs: before
+    env:
+      SHELL: /bin/sh
     strategy:
       matrix:
         os:
@@ -53,7 +55,6 @@ jobs:
             version: devel
     steps:
       - uses: actions/checkout@v2
-      - run: env | grep SHELL || true
       - uses: ./
         with:
           nim-version: ${{ matrix.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
             version: devel
     steps:
       - uses: actions/checkout@v2
+      - run: env | grep SHELL || true
       - uses: ./
         with:
           nim-version: ${{ matrix.version }}

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -88,7 +88,12 @@ function installNim(version, noColor, yes) {
             });
             return;
         }
-        proc.exec('sh init.sh -y', (err, stdout, stderr) => {
+        // #59
+        let execOpts = {
+            env: process.env,
+        };
+        execOpts.env.SHELL = '/bin/sh';
+        proc.exec('sh init.sh -y', execOpts, (err, stdout, stderr) => {
             if (err) {
                 core.error(err);
                 throw err;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -66,7 +66,12 @@ async function installNim(version: string, noColor: boolean, yes: boolean) {
     return
   }
 
-  proc.exec('sh init.sh -y', (err: any, stdout: string, stderr: string) => {
+  // #59
+  let execOpts = {
+    env: process.env,
+  }
+  execOpts.env.SHELL = '/bin/sh'
+  proc.exec('sh init.sh -y', execOpts, (err: any, stdout: string, stderr: string) => {
     if (err) {
       core.error(err)
       throw err

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -71,31 +71,35 @@ async function installNim(version: string, noColor: boolean, yes: boolean) {
     env: process.env,
   }
   execOpts.env.SHELL = '/bin/sh'
-  proc.exec('sh init.sh -y', execOpts, (err: any, stdout: string, stderr: string) => {
-    if (err) {
-      core.error(err)
-      throw err
-    }
-    core.info(stdout)
-
-    // Build optional parameters of choosenim.
-    let opts: string[] = []
-    if (noColor) opts.push('--noColor')
-    if (yes) opts.push('--yes')
-    let optsStr = ''
-    if (0 < opts.length) {
-      optsStr = ' ' + opts.join(' ')
-    }
-
-    proc.exec(
-      `choosenim ${version}${optsStr}`,
-      (err: any, stdout: string, stderr: string) => {
-        if (err) {
-          core.error(err)
-          throw err
-        }
-        core.info(stdout)
+  proc.exec(
+    'sh init.sh -y',
+    execOpts,
+    (err: any, stdout: string, stderr: string) => {
+      if (err) {
+        core.error(err)
+        throw err
       }
-    )
-  })
+      core.info(stdout)
+
+      // Build optional parameters of choosenim.
+      let opts: string[] = []
+      if (noColor) opts.push('--noColor')
+      if (yes) opts.push('--yes')
+      let optsStr = ''
+      if (0 < opts.length) {
+        optsStr = ' ' + opts.join(' ')
+      }
+
+      proc.exec(
+        `choosenim ${version}${optsStr}`,
+        (err: any, stdout: string, stderr: string) => {
+          if (err) {
+            core.error(err)
+            throw err
+          }
+          core.info(stdout)
+        }
+      )
+    }
+  )
 }


### PR DESCRIPTION
> Error message `SHELL: parameter not set`.

I will try appending `SHELL` environment variables when calls `child_process.exec` function in node.js.
`SHELL` environment variables might be removed from GitHub Actions runner.

#59 

