### PR TITLE
Update Readme: cache@v3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ steps:
   - uses: actions/checkout@v3
   - name: Cache nimble
     id: cache-nimble
-    uses: actions/cache@v1
+    uses: actions/cache@v3
     with:
       path: ~/.nimble
       key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
+      restore-keys: |
+        ${{ runner.os }}-nimble-
     if: runner.os != 'Windows'
   - uses: jiro4989/setup-nim-action@v1
     with:


### PR DESCRIPTION
- cache@v1 is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

```sh
Starting today runner version 2.298.2 will begin to warn you 
if you use the save-state or set-output commands via stdout. 
We are monitoring telemetry for the usage of these commands
 and plan to fully disable them on 31st May 2023. Starting 1st 
June 2023 workflows using save-state or set-output 
commands via stdout will fail with an error.
```

- [cache create](https://github.com/noahehall/nim/actions/runs/4310509798/jobs/7519016761)
- [cache restored](https://github.com/noahehall/nim/actions/runs/4310552805/jobs/7519101722#logs)