### PR TITLE
del: windows only conditional branch

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -70,35 +70,7 @@ function installNim(version, noColor, yes) {
         // #483
         // なぜか init.sh を実行したときに 2.x 以降のバージョンをインストールしようとすると非常に遅い。
         // しかし 1.x を一度インストールしてから 2.x に切り替える場合は高速に完了するため、一旦その方法で回避する。
-        process.env.CHOOSENIM_CHOOSE_VERSION = "1.6.0";
-        // #21
-        if (process.platform === 'win32') {
-            proc.execFile('bash', ['init.sh', '-y'], (err, stdout, stderr) => {
-                if (err) {
-                    core.error(err);
-                    throw err;
-                }
-                core.info(stdout);
-                // #41
-                // WindowsのみなぜかZIPファイルが展開されないので一度別バージョンにスイッチ
-                // してから戻すと展開される
-                proc.execFile('choosenim.exe', ['1.4.0'], (err, stdout, stderr) => {
-                    if (err) {
-                        core.error(err);
-                        throw err;
-                    }
-                    core.info(stdout);
-                    proc.execFile('choosenim.exe', util.parseVersion(version), (err, stdout, stderr) => {
-                        if (err) {
-                            core.error(err);
-                            throw err;
-                        }
-                        core.info(stdout);
-                    });
-                });
-            });
-            return;
-        }
+        process.env.CHOOSENIM_CHOOSE_VERSION = '1.6.0';
         const beginDate = Date.now();
         core.info(`Run init.sh`);
         proc.execFile('bash', ['init.sh', '-y'], (err, stdout, stderr) => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -40,48 +40,6 @@ async function installNim(version: string, noColor: boolean, yes: boolean) {
   // しかし 1.x を一度インストールしてから 2.x に切り替える場合は高速に完了するため、一旦その方法で回避する。
   process.env.CHOOSENIM_CHOOSE_VERSION = '1.6.0'
 
-  // #21
-  if (process.platform === 'win32') {
-    proc.execFile(
-      'bash',
-      ['init.sh', '-y'],
-      (err: any, stdout: string, stderr: string) => {
-        if (err) {
-          core.error(err)
-          throw err
-        }
-        core.info(stdout)
-
-        // #41
-        // WindowsのみなぜかZIPファイルが展開されないので一度別バージョンにスイッチ
-        // してから戻すと展開される
-        proc.execFile(
-          'choosenim.exe',
-          ['1.4.0'],
-          (err: any, stdout: string, stderr: string) => {
-            if (err) {
-              core.error(err)
-              throw err
-            }
-            core.info(stdout)
-            proc.execFile(
-              'choosenim.exe',
-              util.parseVersion(version),
-              (err: any, stdout: string, stderr: string) => {
-                if (err) {
-                  core.error(err)
-                  throw err
-                }
-                core.info(stdout)
-              },
-            )
-          },
-        )
-      },
-    )
-    return
-  }
-
   const beginDate = Date.now()
   core.info(`Run init.sh`)
   proc.execFile(


### PR DESCRIPTION
Windows でのみ ZIP ファイルの展開に失敗する問題があって、特殊な条件分岐を用意していたが #485 で Linux においても同様のバージョン切り替えを実装したので、Windows のみの分岐が実質不要になった。

そのため、Windows のみの分岐処理を削除する。