### PR TITLE
BREAKING_CHANGES: installing nim without choosenim 🔥 #483

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
           # - ubuntu-latest
           # - windows-latest
           - macOS-13
+          - macOS-latest
         version:
           - 1.6.0
           - 2.0.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-            # - macOS-latest
+          - macOS-latest
         version:
           - 1.6.0
           - 2.0.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
           - macOS-latest
         version:
           - 2.0.x
+          - devel
+        exclude:
+          - os: windows-latest
+            version: devel
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macOS-13
         version:
           - 1.6.0
           - 2.0.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,65 +13,70 @@ on:
       - '*.md'
 
 jobs:
-  unit-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Run test
-        run: npm test
-      - name: Check unused packages
-        run: npm run check-deps
+  # unit-test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '20'
+  #     - name: Run test
+  #       run: npm test
+  #     - name: Check unused packages
+  #       run: npm run check-deps
 
-  test-actions-on-cross-platform:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macOS-latest
-        version:
-          - 1.4.0
-          - stable
-          - devel
-        exclude:
-          - os: macOS-latest
-            version: 1.4.0
-          - os: macOS-latest
-            version: devel
-          - os: windows-latest
-            version: 1.4.0
-          - os: windows-latest
-            version: devel
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          nim-version: ${{ matrix.version }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print Nim version
-        run: nim -v
-      - name: Print Nimble version
-        run: nimble -v
-      - name: Run build test
-        run: nimble install -Y nimjson
-      - name: Run command
-        run: nimjson -h
+  # test-actions-on-cross-platform:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os:
+  #         - ubuntu-latest
+  #         - windows-latest
+  #         - macOS-latest
+  #       version:
+  #         - 1.4.0
+  #         - stable
+  #         - devel
+  #       exclude:
+  #         - os: macOS-latest
+  #           version: 1.4.0
+  #         - os: macOS-latest
+  #           version: devel
+  #         - os: windows-latest
+  #           version: 1.4.0
+  #         - os: windows-latest
+  #           version: devel
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./
+  #       with:
+  #         nim-version: ${{ matrix.version }}
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+  # 
+  #     - name: Print Nim version
+  #       run: nim -v
+  #     - name: Print Nimble version
+  #       run: nimble -v
+  #     - name: Run build test
+  #       run: nimble install -Y nimjson
+  #     - name: Run command
+  #       run: nimjson -h
 
   test-actions:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         version:
-          - 1.4.x
-          - 1.x
-          - 2.0.x
-          - 2.x
-          - '#version-1-6'
+          - 1.4.0
+          - 1.6.0
+          - 2.0.0
+          - 2.0.6
+          - stable
+          # - 1.4.x
+          # - 1.x
+          # - 2.0.x
+          # - 2.x
+          # - '#version-1-6'
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
+          # - ubuntu-latest
+          # - windows-latest
           - macOS-13
         version:
           - 1.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,55 +13,6 @@ on:
       - '*.md'
 
 jobs:
-  # unit-test:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: '20'
-  #     - name: Run test
-  #       run: npm test
-  #     - name: Check unused packages
-  #       run: npm run check-deps
-
-  # test-actions-on-cross-platform:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - ubuntu-latest
-  #         - windows-latest
-  #         - macOS-latest
-  #       version:
-  #         - 1.4.0
-  #         - stable
-  #         - devel
-  #       exclude:
-  #         - os: macOS-latest
-  #           version: 1.4.0
-  #         - os: macOS-latest
-  #           version: devel
-  #         - os: windows-latest
-  #           version: 1.4.0
-  #         - os: windows-latest
-  #           version: devel
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./
-  #       with:
-  #         nim-version: ${{ matrix.version }}
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  # 
-  #     - name: Print Nim version
-  #       run: nim -v
-  #     - name: Print Nimble version
-  #       run: nimble -v
-  #     - name: Run build test
-  #       run: nimble install -Y nimjson
-  #     - name: Run command
-  #       run: nimjson -h
-
   test-on-cross-platform:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,24 +62,49 @@ jobs:
   #     - name: Run command
   #       run: nimjson -h
 
-  test-actions:
+  test-on-cross-platform:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
-          # - ubuntu-latest
-          # - windows-latest
+          - ubuntu-latest
+          - windows-latest
           - macOS-13
           - macOS-latest
         version:
+          - 2.0.x
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          nim-version: ${{ matrix.version }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print Nim version
+        run: nim -v
+      - name: Print Nimble version
+        run: nimble -v
+      - name: Run build test
+        run: nimble install -Y nimjson
+      - name: Run command
+        run: nimjson -h
+
+  test-multi-versions:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        version:
+          - 1.0.x
+          - 1.2.x
+          - 1.4.x
           - 1.6.0
-          - 2.0.6
+          - 1.6.x
+          - 1.x
+          - 2.0.x
+          - 2.x
           - stable
-          # - 1.4.x
-          # - 1.x
-          # - 2.0.x
-          # - 2.x
-          # - '#version-1-6'
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,6 @@ jobs:
         os:
           - ubuntu-latest
         version:
-          - 1.0.x
-          - 1.2.x
           - 1.4.x
           - 1.6.0
           - 1.6.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,13 +63,15 @@ jobs:
   #       run: nimjson -h
 
   test-actions:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+            # - macOS-latest
         version:
-          - 1.4.0
           - 1.6.0
-          - 2.0.0
           - 2.0.6
           - stable
           # - 1.4.x

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ I changed setup-nim-action so that is does not use choosenim to solve this probl
      with:
        path: ~/.nimble
 -      key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
-+      key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}-v2
++      key: ${{ runner.os }}-nimble-v2-${{ hashFiles('*.nimble') }}
        restore-keys: |
-         ${{ runner.os }}-nimble-
+-        ${{ runner.os }}-nimble-
++        ${{ runner.os }}-nimble-v2-
      if: runner.os != 'Windows'
 
 -  - uses: jiro4989/setup-nim-action@v1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [action.yml](action.yml)
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: jiro4989/setup-nim-action@v2-beta
+  - uses: jiro4989/setup-nim-action@v2
     with:
       nim-version: '2.0.0' # default is 'stable'
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ Setup a latest patch version Nim when `nim-version` is `2.n.x` .
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: jiro4989/setup-nim-action@v2-beta
+  - uses: jiro4989/setup-nim-action@v2
     with:
       nim-version: '2.0.x' # ex: 1.0.x, 1.2.x, 1.4.x, 2.0.x ...
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ Setup a latest minor version Nim when `nim-version` is `2.x` .
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: jiro4989/setup-nim-action@v2-beta
+  - uses: jiro4989/setup-nim-action@v2
     with:
       nim-version: '2.x'
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ steps:
       restore-keys: |
         ${{ runner.os }}-nimble-
     if: runner.os != 'Windows'
-  - uses: jiro4989/setup-nim-action@v2-beta
+  - uses: jiro4989/setup-nim-action@v2
     with:
       repo-token: ${{ secrets.GITHUB_TOKEN }}
   - run: nimble build -Y
@@ -116,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v2-beta
+        uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v2-beta
+        uses: jiro4989/setup-nim-action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: nimble build -Y
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v2-beta
+        uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -179,9 +179,6 @@ jobs:
 ```
 
 ### `devel` usage
-
-:WARN: setup-nim-action@v2 is not supported `devel` version yet.
-Please use v1.
 
 Use `date` cache-key for speed-up if you want to use `devel`.
 See [cache documents](https://github.com/actions/cache) for more information and how to use the cache.
@@ -219,7 +216,7 @@ jobs:
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
           restore-keys: |
             ${{ runner.os }}-nimble-
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: "${{ matrix.nim-version }}"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -248,4 +245,3 @@ And please add [test code](https://github.com/jiro4989/setup-nim-action/tree/mas
 ## :page_facing_up:License
 
 MIT
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 
 <!-- vim-markdown-toc GFM -->
 
-* [Usage](#mag_rightusage)
+* [:mag_right:Usage](#mag_rightusage)
   * [Basic usage](#basic-usage)
   * [Setup a latest patch version Nim](#setup-a-latest-patch-version-nim)
   * [Setup a latest minor version Nim](#setup-a-latest-minor-version-nim)
@@ -14,8 +14,8 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
   * [Matrix testing usage](#matrix-testing-usage)
   * [`devel` usage](#devel-usage)
   * [Full example](#full-example)
-* [Development](#hammerdevelopment)
-* [License](#page_facing_uplicense)
+* [:hammer:Development](#hammerdevelopment)
+* [:page_facing_up:License](#page_facing_uplicense)
 
 <!-- vim-markdown-toc -->
 
@@ -28,7 +28,7 @@ See [action.yml](action.yml)
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: jiro4989/setup-nim-action@v1
+  - uses: jiro4989/setup-nim-action@v2-beta
     with:
       nim-version: '2.0.0' # default is 'stable'
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ steps:
 `repo-token` is using for [Rate limiting](https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting).
 It works without setting this parameter, but please set it if the following error message is returned.
 
-> Error: 403 - {"message":"API rate limit exceeded for nn.nn.nn.nnn. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
+> Error: 403 - {"message":"API rate limit exceeded for nn.nn.nn.nnn. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"<https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}>
 
 ### Setup a latest patch version Nim
 
@@ -48,7 +48,7 @@ Setup a latest patch version Nim when `nim-version` is `2.n.x` .
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: jiro4989/setup-nim-action@v1
+  - uses: jiro4989/setup-nim-action@v2-beta
     with:
       nim-version: '2.0.x' # ex: 1.0.x, 1.2.x, 1.4.x, 2.0.x ...
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ Setup a latest minor version Nim when `nim-version` is `2.x` .
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: jiro4989/setup-nim-action@v1
+  - uses: jiro4989/setup-nim-action@v2-beta
     with:
       nim-version: '2.x'
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ steps:
       restore-keys: |
         ${{ runner.os }}-nimble-
     if: runner.os != 'Windows'
-  - uses: jiro4989/setup-nim-action@v1
+  - uses: jiro4989/setup-nim-action@v2-beta
     with:
       repo-token: ${{ secrets.GITHUB_TOKEN }}
   - run: nimble build -Y
@@ -116,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2-beta
         with:
           nim-version: ${{ matrix.nim }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2-beta
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: nimble build -Y
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2-beta
         with:
           nim-version: ${{ matrix.nim }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -179,6 +179,9 @@ jobs:
 ```
 
 ### `devel` usage
+
+:WARN: setup-nim-action@v2 is not supported `devel` version yet.
+Please use v1.
 
 Use `date` cache-key for speed-up if you want to use `devel`.
 See [cache documents](https://github.com/actions/cache) for more information and how to use the cache.
@@ -234,8 +237,8 @@ This project uses [TypeScript](https://www.typescriptlang.org/).
 Run `npm run build` when you edited source code.
 
 ```bash
-$ vim src/installer.ts
-$ npm run build
+vim src/installer.ts
+npm run build
 ```
 
 `npm run build` command will output a JavaScript file under the `lib` directory. Please commit this.
@@ -245,3 +248,4 @@ And please add [test code](https://github.com/jiro4989/setup-nim-action/tree/mas
 ## :page_facing_up:License
 
 MIT
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 
 * [`v2` version was released :tada:](#v2-version-was-released-tada)
 * [Migration to v2 from v1](#migration-to-v2-from-v1)
+  * [Q&A](#qa)
+    * [getAppFilename failed](#getappfilename-failed)
 * [:mag_right:Usage](#mag_rightusage)
   * [Basic usage](#basic-usage)
   * [Setup a latest patch version Nim](#setup-a-latest-patch-version-nim)
@@ -78,6 +80,40 @@ I changed setup-nim-action so that is does not use choosenim to solve this probl
 -      no-color: yes
    - run: nimble build -Y
    - run: nimble test -Y
+```
+
+### Q&A
+
+#### getAppFilename failed
+
+Please clear cache if you get the following error.
+
+> getAppFilename failed. (Error was: Unable to read /home/runner/.choosenim/current. (Error was: No installation has been chosen. (File missing: /home/runner/.choosenim/current)))
+
+Cache is cleared if you change cache key.
+
+```diff
+     uses: actions/cache@v3
+     with:
+       path: ~/.nimble
+-      key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
++      key: ${{ runner.os }}-nimble-v2-${{ hashFiles('*.nimble') }}
+       restore-keys: |
+-        ${{ runner.os }}-nimble-
++        ${{ runner.os }}-nimble-v2-
+     if: runner.os != 'Windows'
+```
+
+Or please remove actions/cache.
+
+```diff
+-    uses: actions/cache@v3
+-    with:
+-      path: ~/.nimble
+-      key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
+-      restore-keys: |
+-        ${{ runner.os }}-nimble-
+-    if: runner.os != 'Windows'
 ```
 
 ## :mag_right:Usage
@@ -294,3 +330,4 @@ And please add [test code](https://github.com/jiro4989/setup-nim-action/tree/mas
 ## :page_facing_up:License
 
 MIT
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 
 <!-- vim-markdown-toc GFM -->
 
+* [`v2` version was released :tada:](#v2-version-was-released-tada)
 * [Migration to v2 from v1](#migration-to-v2-from-v1)
 * [:mag_right:Usage](#mag_rightusage)
   * [Basic usage](#basic-usage)
@@ -20,12 +21,25 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 
 <!-- vim-markdown-toc -->
 
+## `v2` version was released :tada:
+
+setup-nim-action has released `v2` ( #491 ).
+
+setup-nim-action `v1` depended on `choosenim`.
+One day, an issue occurred that installation became very slow with `choosenim`.
+This process took between 6 and 20 minutes.
+
+I changed setup-nim-action so that is does not use choosenim to solve this problem.
+
 ## Migration to v2 from v1
 
 1. Upgrade version of setup-nim-action to `v2` from `v1`
 1. Change cache key to clear cache if you are using it.
-   The key can be anything if the cache will be cleared
-1. Remove `yes` and `no-color` parameters if you are using it. These parameters are not used now
+   The key can be anything if the cache will be cleared.
+   Nothing to do if you are not using `actions/cache`
+1. Remove `yes` and `no-color` parameters if you are using it.
+   These parameters are not used now.
+   Nothing to do if you are not these parameters
 
 ```diff
  steps:

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ jobs:
 
 ### `devel` usage
 
-Use `date` cache-key for speed-up if you want to use `devel`.
-See [cache documents](https://github.com/actions/cache) for more information and how to use the cache.
+Use `devel` version if you want to use devel compiler of nim.
+setup-nim-action will fetch the devel source code and build the nim compiler every time.
 
 ```yaml
 jobs:
@@ -244,19 +244,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get Date
-        id: get-date
-        run: echo "::set-output name=date::$(date "+%Y-%m-%d")"
-        shell: bash
-
-      - name: Cache choosenim
-        id: cache-choosenim
-        uses: actions/cache@v3
-        with:
-          path: ~/.choosenim
-          key: ${{ runner.os }}-choosenim-${{ matrix.cache-key }}-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-choosenim-${{ matrix.cache-key }}-
       - name: Cache nimble
         id: cache-nimble
         uses: actions/cache@v3
@@ -265,9 +252,10 @@ jobs:
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
           restore-keys: |
             ${{ runner.os }}-nimble-
+
       - uses: jiro4989/setup-nim-action@v2
         with:
-          nim-version: "${{ matrix.nim-version }}"
+          nim-version: devel
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: nimble build

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 setup-nim-action has released `v2` ( <https://github.com/jiro4989/setup-nim-action/pull/491> ).
 
 setup-nim-action `v1` depended on `choosenim`.
-One day, an issue occurred that installation became very slow with `choosenim`.
+One day, an issue occurred that installation became very slow with `choosenim` ( <https://github.com/jiro4989/setup-nim-action/issues/483> ).
 This process took between 6 and 20 minutes.
 
 I changed setup-nim-action so that is does not use choosenim to solve this problem.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 
 ## `v2` version was released :tada:
 
-setup-nim-action has released `v2` ( #491 ).
+setup-nim-action has released `v2` ( <https://github.com/jiro4989/setup-nim-action/pull/491> ).
 
 setup-nim-action `v1` depended on `choosenim`.
 One day, an issue occurred that installation became very slow with `choosenim`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 
 <!-- vim-markdown-toc GFM -->
 
+* [Migration to v2 from v1](#migration-to-v2-from-v1)
 * [:mag_right:Usage](#mag_rightusage)
   * [Basic usage](#basic-usage)
   * [Setup a latest patch version Nim](#setup-a-latest-patch-version-nim)
@@ -18,6 +19,39 @@ This action sets up a [Nim-lang](https://nim-lang.org/):crown: environment.
 * [:page_facing_up:License](#page_facing_uplicense)
 
 <!-- vim-markdown-toc -->
+
+## Migration to v2 from v1
+
+1. Upgrade version of setup-nim-action to `v2` from `v1`
+1. Change cache key to clear cache if you are using it.
+   The key can be anything if the cache will be cleared
+1. Remove `yes` and `no-color` parameters if you are using it. These parameters are not used now
+
+```diff
+ steps:
+   - uses: actions/checkout@v3
+
+   - name: Cache nimble
+     id: cache-nimble
+     uses: actions/cache@v3
+     with:
+       path: ~/.nimble
+-      key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
++      key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}-v2
+       restore-keys: |
+         ${{ runner.os }}-nimble-
+     if: runner.os != 'Windows'
+
+-  - uses: jiro4989/setup-nim-action@v1
++  - uses: jiro4989/setup-nim-action@v2
+     with:
+       nim-version: '2.0.0' # default is 'stable'
+       repo-token: ${{ secrets.GITHUB_TOKEN }}
+-      yes: false
+-      no-color: yes
+   - run: nimble build -Y
+   - run: nimble test -Y
+```
 
 ## :mag_right:Usage
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ I changed setup-nim-action so that is does not use choosenim to solve this probl
 1. Change cache key to clear cache if you are using it.
    The key can be anything if the cache will be cleared.
    Nothing to do if you are not using `actions/cache`
+1. Remove caching `choosenim` if you are using it.
+   setup-nim-action does not use choosenim now.
+   Nothing to do if you are not these parameters
 1. Remove `yes` and `no-color` parameters if you are using it.
    These parameters are not used now.
    Nothing to do if you are not these parameters
@@ -56,6 +59,15 @@ I changed setup-nim-action so that is does not use choosenim to solve this probl
 -        ${{ runner.os }}-nimble-
 +        ${{ runner.os }}-nimble-v2-
      if: runner.os != 'Windows'
+
+-  - name: Cache choosenim
+-    id: cache-choosenim
+-    uses: actions/cache@v3
+-    with:
+-      path: ~/.choosenim
+-      key: ${{ runner.os }}-choosenim-${{ matrix.cache-key }}-${{ steps.get-date.outputs.date }}
+-      restore-keys: |
+-        ${{ runner.os }}-choosenim-${{ matrix.cache-key }}-
 
 -  - uses: jiro4989/setup-nim-action@v1
 +  - uses: jiro4989/setup-nim-action@v2

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
     - name: Set PATH for Unix
       shell: bash
       run: |
+        uname -m
         echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
       if: runner.os != 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         export CHOOSENIM_NO_ANALYTICS=1
         curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
         chmod +x init.sh
-        ./init.sh -n
+        ./init.sh -y
 
     - name: Switch nim version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
       The Nim version to download (if necessary)
       and use. Example 1.0.2
     default: '.nim_runtime'
+  no-color:
+    description: 'Activate "--noColor" options of choosenim. Example: true'
+    default: false
+  "yes":
+    description: 'Activate "--yes" options of choosenim. Example: true'
+    default: false
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,11 @@ inputs:
       The Nim version to download (if necessary)
       and use. Example 1.0.2
     default: 'stable'
+  nim-install-directory:
+    description: >-
+      The Nim version to download (if necessary)
+      and use. Example 1.0.2
+    default: '.nim_runtime'
   no-color:
     description: 'Activate "--noColor" options of choosenim. Example: true'
     default: false
@@ -25,6 +30,6 @@ runs:
     - name: Install nim
       shell: bash
       run: |
-        ./install_nim.sh
-        echo "$PWD/.nim_runtime/bin" >> "$GITHUB_PATH"
+        ./install_nim.sh --nim-version ${{ inputs.nim-version }} --nim-install-directory ${{ inputs.nim-install-directory }}
+        echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-      if: ${{ runner.os }} != "Windows"
+      if: runner.os != 'Windows'
 
     - name: Set PATH on Windows
       shell: bash
@@ -48,4 +48,4 @@ runs:
         cygpath "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         cygpath "$HOME/.nimble/bin" >> "$GITHUB_PATH"
         cat "$GITHUB_PATH"
-      if: ${{ runner.os }} == "Windows"
+      if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,6 @@ runs:
       shell: pwsh
       run: |
         echo "$Pwd\${{ inputs.nim-install-directory }}\bin" >> $Env:GITHUB_PATH
+        mkdir -Force ~\.nimble\bin
         (Resolve-Path ~\.nimble\bin).Path >> $Env:GITHUB_PATH
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,7 @@
 name: 'Setup Nim environment'
 description: 'Setup a Nim environment and add it to the PATH'
 author: 'jiro4989'
+
 inputs:
   nim-version:
     description: >-
@@ -17,6 +18,18 @@ inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: false
+
 runs:
-  using: 'node20'
-  main: 'lib/setup-nim.js'
+  using: 'composite'
+  steps:
+    - name: Install choosenim
+      shell: bash
+      run: |
+        curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
+        chmod +x init.sh
+        ./init.sh -y
+
+    - name: Switch nim version
+      shell: bash
+      run: |
+        choosenim ${{ inputs.nim-version }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Install nim
       shell: bash
       run: |
-        ./install_nim.sh \
+        "${{ github.action_path }}/install_nim.sh" \
           --nim-version "${{ inputs.nim-version }}" \
           --nim-install-directory "${{ inputs.nim-install-directory }}" \
           --os "${{ runner.os }}" \

--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,6 @@ inputs:
       The Nim version to download (if necessary)
       and use. Example 1.0.2
     default: '.nim_runtime'
-  no-color:
-    description: 'Activate "--noColor" options of choosenim. Example: true'
-    default: false
-  "yes":
-    description: 'Activate "--yes" options of choosenim. Example: true'
-    default: false
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
         chmod +x init.sh
-        ./init.sh -y
+        ./init.sh -n
 
     - name: Switch nim version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,3 +44,11 @@ runs:
         mkdir -Force ~\.nimble\bin
         (Resolve-Path ~\.nimble\bin).Path >> $Env:GITHUB_PATH
       if: runner.os == 'Windows'
+
+    - name: Print nim version
+      shell: bash
+      run: nim -v
+
+    - name: Print nimble version
+      shell: bash
+      run: nimble -v

--- a/action.yml
+++ b/action.yml
@@ -31,14 +31,14 @@ runs:
       shell: bash
       run: |
         ./install_nim.sh \
-          --nim-version ${{ inputs.nim-version }} \
-          --nim-install-directory ${{ inputs.nim-install-directory }} \
-          --os ${{ runner.os }}
+          --nim-version "${{ inputs.nim-version }}" \
+          --nim-install-directory "${{ inputs.nim-install-directory }}" \
+          --os "${{ runner.os }}" \
+          --repo-token "${{ inputs.repo-token }}"
 
     - name: Set PATH for Unix
       shell: bash
       run: |
-        uname -m
         echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
       if: runner.os != 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -26,3 +26,5 @@ runs:
       shell: bash
       run: |
         ./install_nim.sh
+        echo "$PWD/.nim_runtime/bin" >> "$GITHUB_PATH"
+        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -35,14 +35,14 @@ runs:
           --nim-install-directory ${{ inputs.nim-install-directory }} \
           --os ${{ runner.os }}
 
-    - name: Set PATH on Unix
+    - name: Set PATH for Unix
       shell: bash
       run: |
         echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
       if: runner.os != 'Windows'
 
-    - name: Set PATH on Windows
+    - name: Set PATH for Windows
       shell: pwsh
       run: |
         echo "$Pwd\${{ inputs.nim-install-directory }}\bin" >> $Env:GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
     - name: Install choosenim
       shell: bash
       run: |
+        export CHOOSENIM_NO_ANALYTICS=1
         curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
         chmod +x init.sh
         ./init.sh -n

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,7 @@ inputs:
     default: 'stable'
   nim-install-directory:
     description: >-
-      The Nim version to download (if necessary)
-      and use. Example 1.0.2
+      The Nim compiler installation directory.
     default: '.nim_runtime'
   repo-token:
     description: 'The GITHUB_TOKEN secret'

--- a/action.yml
+++ b/action.yml
@@ -43,9 +43,8 @@ runs:
       if: runner.os != 'Windows'
 
     - name: Set PATH on Windows
-      shell: bash
+      shell: pwsh
       run: |
-        cygpath "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
-        cygpath "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-        "$PWD/${{ inputs.nim-install-directory }}/bin/nim.exe" --version
+        echo "$Pwd\${{ inputs.nim-install-directory }}\bin" >> $Env:GITHUB_PATH
+        (Resolve-Path ~\.nimble\bin).Path >> $Env:GITHUB_PATH
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ runs:
     - name: Install nim
       shell: bash
       run: |
-        ./install_nim.sh --nim-version ${{ inputs.nim-version }} --nim-install-directory ${{ inputs.nim-install-directory }}
+        ./install_nim.sh \
+          --nim-version ${{ inputs.nim-version }} \
+          --nim-install-directory ${{ inputs.nim-install-directory }} \
+          --os ${{ runner.os }}
         echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ runs:
       run: |
         cygpath "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         cygpath "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-        cat "$GITHUB_PATH"
+        "$PWD/${{ inputs.nim-install-directory }}/bin/nim.exe" --version
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -22,15 +22,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install choosenim
+    - name: Install nim
       shell: bash
       run: |
-        export CHOOSENIM_NO_ANALYTICS=1
-        curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
-        chmod +x init.sh
-        ./init.sh -y
-
-    - name: Switch nim version
-      shell: bash
-      run: |
-        choosenim ${{ inputs.nim-version }}
+        ./install_nim.sh

--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,17 @@ runs:
           --nim-version ${{ inputs.nim-version }} \
           --nim-install-directory ${{ inputs.nim-install-directory }} \
           --os ${{ runner.os }}
+
+    - name: Set PATH on Unix
+      shell: bash
+      run: |
         echo "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+      if: ${{ runner.os }} != "Windows"
+
+    - name: Set PATH on Windows
+      shell: bash
+      run: |
+        cygpath "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
+        cygpath "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+      if: ${{ runner.os }} == "Windows"

--- a/action.yml
+++ b/action.yml
@@ -14,15 +14,15 @@ inputs:
       The Nim version to download (if necessary)
       and use. Example 1.0.2
     default: '.nim_runtime'
-  no-color:
-    description: 'Activate "--noColor" options of choosenim. Example: true'
-    default: false
-  "yes":
-    description: 'Activate "--yes" options of choosenim. Example: true'
-    default: false
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: false
+  no-color:
+    description: '[Deprecated] unused parameter'
+    default: false
+  "yes":
+    description: '[Deprecated] unused parameter'
+    default: false
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -47,4 +47,5 @@ runs:
       run: |
         cygpath "$PWD/${{ inputs.nim-install-directory }}/bin" >> "$GITHUB_PATH"
         cygpath "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+        cat "$GITHUB_PATH"
       if: ${{ runner.os }} == "Windows"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -38,6 +38,7 @@ if [[ "$nim_version" = "stable" ]]; then
   nim_version="$(fetch_tags | jq -r '.[].ref' | sort -V | tail -n 1 | sed -E 's:^refs/tags/v::')"
 fi
 
+# download nim compiler
 arch="x64"
 if [[ "$os" = Windows ]]; then
   download_url="https://nim-lang.org/download/nim-${nim_version}_${arch}.zip"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -6,6 +6,7 @@ fetch_tags() {
   # https://docs.github.com/ja/rest/git/refs?apiVersion=2022-11-28
   curl \
     -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${INPUT_REPO_TOKEN}" \
     -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/nim-lang/nim/git/refs/tags
 }
 
@@ -26,9 +27,6 @@ while ((0 < $#)); do
     --os)
       os=$1
       ;;
-    # --repo-token)
-    #   repo_token=$1
-    #   ;;
   esac
 done
 

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -54,11 +54,13 @@ elif [[ "$os" = macOS ]]; then
   tar xf nim.tar.xz
   rm -f nim.tar.xz
 
+  # homebrew: https://github.com/Homebrew/homebrew-core/blob/736836cf038c04e304e635ccd04dcd0bdff8f57b/Formula/n/nim.rb
+  # nim: https://github.com/nim-lang/Nim/blob/devel/build_all.sh
   cd "nim-${nim_version}"
   ./build.sh
-  ./bin/nim c -d:release koch
-  ./koch boot -d:release -d:useLinenoise
-  ./koch tools
+  ./bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch
+  ./koch boot -d:release --skipUserCfg --skipParentCfg --hints:off
+  ./koch tools --skipUserCfg --skipParentCfg --hints:off
   cd ..
 else
   download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -40,6 +40,10 @@ fi
 
 # download nim compiler
 arch="x64"
+if [[ $(uname -m) = arm64 ]]; then
+  arch="arm64"
+fi
+
 if [[ "$os" = Windows ]]; then
   download_url="https://nim-lang.org/download/nim-${nim_version}_${arch}.zip"
   curl -sSL "${download_url}" > nim.zip

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -6,7 +6,7 @@ fetch_tags() {
   # https://docs.github.com/ja/rest/git/refs?apiVersion=2022-11-28
   curl \
     -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer ${INPUT_REPO_TOKEN}" \
+    -H "Authorization: Bearer ${repo_token}" \
     -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/nim-lang/nim/git/refs/tags
 }
 
@@ -14,6 +14,7 @@ fetch_tags() {
 nim_version="stable"
 nim_install_dir=".nim_runtime"
 os="Linux"
+repo_token=""
 while ((0 < $#)); do
   opt=$1
   shift
@@ -26,6 +27,9 @@ while ((0 < $#)); do
       ;;
     --os)
       os=$1
+      ;;
+    --repo-token)
+      repo_token=$1
       ;;
   esac
 done

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -55,6 +55,7 @@ elif [[ "$os" = macOS ]]; then
   rm -f nim.tar.xz
 
   cd "nim-${nim_version}"
+  ls
   sh build_all.sh
   ./koch boot -d:release -d:useLinenoise
   cd ..

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -55,7 +55,7 @@ elif [[ "$os" = macOS ]]; then
   rm -f nim.tar.xz
 
   cd "nim-${nim_version}"
-  ./build_all.sh
+  sh build_all.sh
   ./koch boot -d:release -d:useLinenoise
   cd ..
 else

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -10,6 +10,10 @@ fetch_tags() {
     -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/nim-lang/nim/git/refs/tags
 }
 
+info() {
+  echo "$(date) [INFO] $*"
+}
+
 # parse commandline args
 nim_version="stable"
 nim_install_dir=".nim_runtime"
@@ -48,7 +52,7 @@ if [[ "$os" = Windows ]]; then
   unzip -q nim.zip
   rm -f nim.zip
 elif [[ "$os" = macOS ]]; then
-  # Need to build compiler
+  # need to build compiler
   download_url="https://nim-lang.org/download/nim-${nim_version}.tar.xz"
   curl -sSL "${download_url}" > nim.tar.xz
   tar xf nim.tar.xz
@@ -57,10 +61,19 @@ elif [[ "$os" = macOS ]]; then
   # homebrew: https://github.com/Homebrew/homebrew-core/blob/736836cf038c04e304e635ccd04dcd0bdff8f57b/Formula/n/nim.rb
   # nim: https://github.com/nim-lang/Nim/blob/devel/build_all.sh
   cd "nim-${nim_version}"
+
+  info "build nim compiler"
   ./build.sh
+
+  info "build koch tool"
   ./bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch
+
+  info "koch boot"
   ./koch boot -d:release --skipUserCfg --skipParentCfg --hints:off
+
+  info "koch tools"
   ./koch tools --skipUserCfg --skipParentCfg --hints:off
+
   cd ..
 else
   download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -56,8 +56,10 @@ elif [[ "$os" = macOS ]]; then
 
   cd "nim-${nim_version}"
   ls
-  sh build_all.sh
+  ./build.sh
+  ./bin/nim c -d:release koch
   ./koch boot -d:release -d:useLinenoise
+  ./koch tools
   cd ..
 else
   download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -40,17 +40,16 @@ fi
 
 # download nim compiler
 arch="x64"
-if [[ $(uname -m) = arm64 ]]; then
-  arch="arm64"
-fi
-
 if [[ "$os" = Windows ]]; then
   download_url="https://nim-lang.org/download/nim-${nim_version}_${arch}.zip"
   curl -sSL "${download_url}" > nim.zip
   unzip -q nim.zip
   rm -f nim.zip
 else
-  download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"
+  if [[ "$os" = macOS ]]; then
+    os="macosx"
+  fi
+  download_url="https://nim-lang.org/download/nim-${nim_version}-${os}_${arch}.tar.xz"
   curl -sSL "${download_url}" > nim.tar.xz
   tar xf nim.tar.xz
   rm -f nim.tar.xz

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -45,12 +45,19 @@ if [[ "$os" = Windows ]]; then
   curl -sSL "${download_url}" > nim.zip
   unzip -q nim.zip
   rm -f nim.zip
+elif [[ "$os" = macOS ]]; then
+  # Need to build compiler
+  download_url="https://nim-lang.org/download/nim-${nim_version}.tar.xz"
+  curl -sSL "${download_url}" > nim.tar.xz
+  tar xf nim.tar.xz
+  rm -f nim.tar.xz
+
+  cd "nim-${nim_version}"
+  ./build_all.sh
+  ./koch boot -d:release -d:useLinenoise
+  cd ..
 else
-  os="linux"
-  if [[ "$os" = macOS ]]; then
-    os="macosx"
-  fi
-  download_url="https://nim-lang.org/download/nim-${nim_version}-${os}_${arch}.tar.xz"
+  download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"
   curl -sSL "${download_url}" > nim.tar.xz
   tar xf nim.tar.xz
   rm -f nim.tar.xz

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -12,8 +12,4 @@ mkdir -p "${output_dir}"
 cd "${output_dir}"
 curl -sSL "${download_url}" > nim.tar.xz
 tar xf nim.tar.xz --strip-components 1
-export PATH=${PATH}:${PWD}/bin
 cd ..
-
-nim --version
-nimble --version

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -46,6 +46,7 @@ if [[ "$os" = Windows ]]; then
   unzip -q nim.zip
   rm -f nim.zip
 else
+  os="linux"
   if [[ "$os" = macOS ]]; then
     os="macosx"
   fi

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -55,7 +55,6 @@ elif [[ "$os" = macOS ]]; then
   rm -f nim.tar.xz
 
   cd "nim-${nim_version}"
-  ls
   ./build.sh
   ./bin/nim c -d:release koch
   ./koch boot -d:release -d:useLinenoise

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -42,7 +42,7 @@ arch="x64"
 if [[ "$os" = Windows ]]; then
   download_url="https://nim-lang.org/download/nim-${nim_version}_${arch}.zip"
   curl -sSL "${download_url}" > nim.zip
-  unzip nim.zip
+  unzip -q nim.zip
   rm -f nim.zip
 else
   download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -2,8 +2,16 @@
 
 set -eu
 
+fetch_tags() {
+  # https://docs.github.com/ja/rest/git/refs?apiVersion=2022-11-28
+  curl \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/nim-lang/nim/git/refs/tags
+}
+
 output_dir=".nim_runtime"
-nim_version="2.0.8"
+# nim_version="2.0.8"
+nim_version="$(fetch_tags | jq -r '.[].ref' | sort -V | tail -n 1 | sed -E 's:^refs/tags/v::')"
 os="linux"
 arch="x64"
 download_url="https://nim-lang.org/download/nim-${nim_version}-${os}_${arch}.tar.xz"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -9,15 +9,37 @@ fetch_tags() {
     -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/nim-lang/nim/git/refs/tags
 }
 
-output_dir=".nim_runtime"
-# nim_version="2.0.8"
-nim_version="$(fetch_tags | jq -r '.[].ref' | sort -V | tail -n 1 | sed -E 's:^refs/tags/v::')"
+# parse commandline args
+nim_version="stable"
+nim_install_dir=".nim_runtime"
+while ((0 < $#)); do
+  opt=$1
+  shift
+  case $opt in
+    --nim-version)
+      nim_version=$1
+      ;;
+    --nim-install-directory)
+      nim_install_dir=$1
+      ;;
+    # --repo-token)
+    #   repo_token=$1
+    #   ;;
+  esac
+done
+
+# fetch latest tag if 'nim_version' was 'stable'
+if [[ "$nim_version" = "stable" ]]; then
+  # NOTE: jq is pre-installed on github actions runner
+  nim_version="$(fetch_tags | jq -r '.[].ref' | sort -V | tail -n 1 | sed -E 's:^refs/tags/v::')"
+fi
+
 os="linux"
 arch="x64"
 download_url="https://nim-lang.org/download/nim-${nim_version}-${os}_${arch}.tar.xz"
 
-mkdir -p "${output_dir}"
-cd "${output_dir}"
+mkdir -p "${nim_install_dir}"
+cd "${nim_install_dir}"
 curl -sSL "${download_url}" > nim.tar.xz
 tar xf nim.tar.xz --strip-components 1
 cd ..

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+output_dir=".nim_runtime"
+nim_version="2.0.8"
+os="linux"
+arch="x64"
+download_url="https://nim-lang.org/download/nim-${nim_version}-${os}_${arch}.tar.xz"
+
+mkdir -p "${output_dir}"
+cd "${output_dir}"
+curl -sSL "${download_url}" > nim.tar.xz
+tar xf nim.tar.xz --strip-components 1
+export PATH=${PATH}:${PWD}/bin
+cd ..
+
+nim --version
+nimble --version

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -12,6 +12,7 @@ fetch_tags() {
 # parse commandline args
 nim_version="stable"
 nim_install_dir=".nim_runtime"
+os="Linux"
 while ((0 < $#)); do
   opt=$1
   shift
@@ -21,6 +22,9 @@ while ((0 < $#)); do
       ;;
     --nim-install-directory)
       nim_install_dir=$1
+      ;;
+    --os)
+      os=$1
       ;;
     # --repo-token)
     #   repo_token=$1
@@ -34,12 +38,16 @@ if [[ "$nim_version" = "stable" ]]; then
   nim_version="$(fetch_tags | jq -r '.[].ref' | sort -V | tail -n 1 | sed -E 's:^refs/tags/v::')"
 fi
 
-os="linux"
 arch="x64"
-download_url="https://nim-lang.org/download/nim-${nim_version}-${os}_${arch}.tar.xz"
-
-mkdir -p "${nim_install_dir}"
-cd "${nim_install_dir}"
-curl -sSL "${download_url}" > nim.tar.xz
-tar xf nim.tar.xz --strip-components 1
-cd ..
+if [[ "$os" = Windows ]]; then
+  download_url="https://nim-lang.org/download/nim-${nim_version}_${arch}.zip"
+  curl -sSL "${download_url}" > nim.zip
+  unzip nim.zip
+  rm -f nim.zip
+else
+  download_url="https://nim-lang.org/download/nim-${nim_version}-linux_${arch}.tar.xz"
+  curl -sSL "${download_url}" > nim.tar.xz
+  tar xf nim.tar.xz
+  rm -f nim.tar.xz
+fi
+mv "nim-${nim_version}" "${nim_install_dir}"

--- a/install_nim.sh
+++ b/install_nim.sh
@@ -16,6 +16,10 @@ info() {
   echo "$(date) [INFO] $*"
 }
 
+err() {
+  echo "$(date) [ERR] $*"
+}
+
 tag_regexp() {
   version=$1
   echo "$version" |
@@ -52,6 +56,23 @@ while ((0 < $#)); do
       ;;
   esac
 done
+
+# build nim compiler for deve branch
+if [[ "$nim_version" = "devel" ]]; then
+  if [[ "$os" = Windows ]]; then
+    err "'devel' version and windows runner are not supported yet"
+    exit 1
+  fi
+
+  git clone -b devel --depth 1 https://github.com/nim-lang/Nim
+  cd Nim
+  info "build nim compiler (devel)"
+  ./build_all.sh
+  cd ..
+  mv Nim "${nim_install_dir}"
+
+  exit
+fi
 
 # fetch latest tag if 'nim_version' was 'stable'
 if [[ "$nim_version" = "stable" ]]; then

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -71,6 +71,13 @@ function installNim(version, noColor, yes) {
         // なぜか init.sh を実行したときに 2.x 以降のバージョンをインストールしようとすると非常に遅い。
         // しかし 1.x を一度インストールしてから 2.x に切り替える場合は高速に完了するため、一旦その方法で回避する。
         process.env.CHOOSENIM_CHOOSE_VERSION = '1.6.0';
+        // #483
+        // Mac 環境では choosenim インストール後の切り替えすらも非常に遅いので、
+        // 一度インストールしたら切り替え操作はしない。
+        const isMac = process.platform === 'darwin';
+        if (isMac) {
+            process.env.CHOOSENIM_CHOOSE_VERSION = version;
+        }
         const beginDate = Date.now();
         core.info(`Run init.sh`);
         proc.execFile('bash', ['init.sh', '-y'], (err, stdout, stderr) => {
@@ -82,6 +89,12 @@ function installNim(version, noColor, yes) {
             const elapsed = endDate - beginDate;
             core.info(stdout);
             core.info(`Succeeded to run init.sh: elapsed = ${elapsed} millisecond`);
+            // #483
+            // Mac 環境では choosenim インストール後の切り替えすらも非常に遅いので、
+            // 一度インストールしたら切り替え操作はしない。
+            if (isMac) {
+                return;
+            }
             // Build optional parameters of choosenim.
             let args = util.parseVersion(version);
             if (noColor)

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -40,6 +40,14 @@ async function installNim(version: string, noColor: boolean, yes: boolean) {
   // しかし 1.x を一度インストールしてから 2.x に切り替える場合は高速に完了するため、一旦その方法で回避する。
   process.env.CHOOSENIM_CHOOSE_VERSION = '1.6.0'
 
+  // #483
+  // Mac 環境では choosenim インストール後の切り替えすらも非常に遅いので、
+  // 一度インストールしたら切り替え操作はしない。
+  const isMac = process.platform === 'darwin'
+  if (isMac) {
+    process.env.CHOOSENIM_CHOOSE_VERSION = version
+  }
+
   const beginDate = Date.now()
   core.info(`Run init.sh`)
   proc.execFile(
@@ -54,6 +62,13 @@ async function installNim(version: string, noColor: boolean, yes: boolean) {
       const elapsed = endDate - beginDate
       core.info(stdout)
       core.info(`Succeeded to run init.sh: elapsed = ${elapsed} millisecond`)
+
+      // #483
+      // Mac 環境では choosenim インストール後の切り替えすらも非常に遅いので、
+      // 一度インストールしたら切り替え操作はしない。
+      if (isMac) {
+        return
+      }
 
       // Build optional parameters of choosenim.
       let args: string[] = util.parseVersion(version)


### PR DESCRIPTION
## 概要

1. choosenim を使用して nim をインストールする際、2 系をインストールしようとすると非常に遅くなることがある
   1. また、Mac の場合は 1 系 2 系を問わず 20 分ほどインストールに時間がかかってしまい、非常に遅い
3. これは node20 runtime のカスタムアクションで choosenim を実行した場合でも、[composite カスタムアクション](https://docs.github.com/ja/actions/creating-actions/creating-a-composite-action)で実行した場合でも発生する
4. choosenim を使わずに Nim コンパイラをインストールする方式だと、Linux, Mac, Windows のいずれも高速にインストールできることがわかった
   1. Linux, Windows では 10 秒以内
   2. Mac では 6 分ほど。これは Nim 公式がビルド済みの Mac 向けコンパイラを提供していないため、CI で都度コンパイラをビルドするため、時間がかかっている
   3. それでも 20 分かかっていた頃よりは十分高速に完了する
6. そのため、今までずっと choosenim を使ってインストールしていた処理を、すべてシェルスクリプトでインストールするように実装を変更する

## 変更の詳細

1. カスタムアクションのランタイムを node20 から composite に変更
2. typescript で実装していたインストール処理をシェルスクリプトに変更
   1. Linux, Windows はビルド済みコンパイラが存在するため、コンパイラの取得処理のみ
   2. Mac はビルド済みコンパイラがなさそうだったため、[homebrew のインストール処理](https://github.com/Homebrew/homebrew-core/blob/736836cf038c04e304e635ccd04dcd0bdff8f57b/Formula/n/nim.rb)と、[Nim 公式リポジトリのインストール処理](https://github.com/nim-lang/Nim/blob/devel/build_all.sh)を参考に、CI 上でコンパイラをビルドするようにした
      1. build_all.sh は古いバージョンの nim だとそもそもスクリプトが存在しなかったため、build_all.sh の実装をそのまま移植するような形で実装した
3. Nim コンパイラはカレントディレクトリ配下に隠しフォルダとして配置するように変更
   1. このインストール先は inputs の `nim-install-directory` にて変更可能
4. `$PWD/隠しフォルダ/bin` と `$HOME/.nimble/bin` に PATH を通すように変更
5. choosenim 用に用意していた inputs の `no-coler` と `yes` が不要になったため、非推奨パラメータとした
   1. いきなり削除すると CI が壊れるところもありそうだったため、一旦非推奨で残す
6. 実装の変更にあわせて CI によるテスト内容を変更
   1. macOS-latest ( macOS-14 ) は CPU アーキテクチャが arm64 のみ提供されている ( https://github.com/actions/runner-images/issues/9741 )
   2. macOS-13 は x64 のまま。そのため macOS runner でのみ macOS-13 と 14 をテストするようにした

## 破壊的変更 🔥 

1. ランタイムを node20 から composite に変更
   1. 依存ライブラリなどが変化するため、なんらか node ランタイムに依存していたプロジェクトが存在した場合問題が発生するかもしれない
3. Nim コンパイラはカレントディレクトリ配下に隠しフォルダとして配置するように変更
   1. もしカレントディレクトリで .nim_runtime といったフォルダを作ったりする処理があった場合、影響がでるかもしれない

## リリースフロー

1. 今回の変更は初めてのメジャーバージョンアップであり、破壊的変更を伴うため慎重にバージョンを上げる
3. `devel` ブランチを切り、そこで `v2-beta` タグを発行する
4. 次に自身のいくつかのリポジトリで v2-beta に切り替えて CI を動作して、処理時間を確認する
5. #483 にて共有し、自分以外の方に動作確認の協力を仰ぐ
6. 動作に問題がなければ master マージして v2 タグを発行する

## 未対応の事項

1. Typescript 周りのソースコードの削除はあとで対応する
2. `devel` バージョンを指定されても、現状正常に動作しないが、後で対応する

#483 