### PR TITLE
feat: add `use-nightlies` parameter #504

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,30 @@ jobs:
       - name: Run command
         run: nimjson -h
 
+  test-devel:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          nim-version: devel
+          use-nightlies: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print Nim version
+        run: nim -v
+      - name: Print Nimble version
+        run: nimble -v
+      - name: Run build test
+        run: nimble install -Y nimjson
+      - name: Run command
+        run: nimjson -h
+
   test-multi-versions:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ jobs:
 
 ### `devel` usage
 
-Use `devel` version if you want to use devel compiler of nim.
+Use `devel` version if you want to use devel compiler of Nim.
 setup-nim-action will fetch the devel source code and build the nim compiler every time.
 
 ```yaml
@@ -300,6 +300,34 @@ jobs:
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: devel
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: nimble build -Y
+```
+
+But building the devel compiler takes a long time.
+If you don't want to build it every time, set `use-nightlies` to `true`.
+
+```yaml
+jobs:
+  test_devel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache nimble
+        id: cache-nimble
+        uses: actions/cache@v4
+        with:
+          path: ~/.nimble
+          key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
+          restore-keys: |
+            ${{ runner.os }}-nimble-
+
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: devel
+          use-nightlies: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: nimble build -Y

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ inputs:
       The Nim compiler installation parent directory.
       It will be placed in the current directory if this parameter is empty.
     default: ''
+  use-nightlies:
+    description: >-
+      Using nightlies build (https://github.com/nim-lang/nightlies/releases) if `nim-version` is `devel`.
+      The installation will be fast if this parameter is `true`.
+      If `nim-version` is not `devel`, then this parameter has no effect.
+    default: false
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: false
@@ -42,6 +48,7 @@ runs:
           --parent-nim-install-directory "${{ inputs.parent-nim-install-directory }}" \
           --nim-install-directory "${{ inputs.nim-install-directory }}" \
           --os "${{ runner.os }}" \
+          --use-nightlies "${{ inputs.use-nightlies }}" \
           --repo-token "${{ inputs.repo-token }}"
 
     - name: Set PATH for Unix


### PR DESCRIPTION
## Overview

* add `use-nightlies` parameter. Installing [nightlies build](https://github.com/nim-lang/nightlies/releases) if this parameter is `true`. Default values is `false`.
* add CI tests for `use-nightlies` parameter
* add usecase to README for `use-nightlies` parameter

#504