### PR TITLE
fix: remove directory if cached directory exists

### DIFF
--- a/install_nim.sh
+++ b/install_nim.sh
@@ -50,6 +50,14 @@ latest_version() {
   sort -V | tail -n 1
 }
 
+remove_cached_directory() {
+  cached_dir="$1"
+  if [[ -d "$cached_dir" ]]; then
+    info "remove cached directory (path = $cached_dir)"
+    rm -rf "$cached_dir"
+  fi
+}
+
 # parse commandline args
 nim_version="stable"
 nim_install_dir=".nim_runtime"
@@ -118,6 +126,7 @@ if [[ "$nim_version" = "devel" ]]; then
     rm -f "$asset_name"
 
     popd
+    remove_cached_directory "${nim_install_dir}"
     mv "${work_dir}/outfiles" "${nim_install_dir}"
     rm -rf "$work_dir"
   else
@@ -126,6 +135,7 @@ if [[ "$nim_version" = "devel" ]]; then
     info "build nim compiler (devel)"
     ./build_all.sh
     cd ..
+    remove_cached_directory "${nim_install_dir}"
     mv Nim "${nim_install_dir}"
   fi
 
@@ -178,4 +188,5 @@ else
   tar xf nim.tar.xz
   rm -f nim.tar.xz
 fi
+remove_cached_directory "${nim_install_dir}"
 mv "nim-${nim_version}" "${nim_install_dir}"


### PR DESCRIPTION
Remove directory if cached directory exists.

The installation will not work properly if the cache directory exists.

Ex:

```bash
jiro4989@jiro4989 /t/work> mkdir example1
jiro4989@jiro4989 /t/work> echo 1 > example1/1.txt
jiro4989@jiro4989 /t/work> mkdir example2
jiro4989@jiro4989 /t/work> echo 2 > example2/2.txt
jiro4989@jiro4989 /t/work> mv example2 example1
jiro4989@jiro4989 /t/work> find example1
example1
example1/1.txt
example1/example2
example1/example2/2.txt
```